### PR TITLE
Development compatibility with Ecocyc 28.0

### DIFF
--- a/DatamartExtractorSummary.md
+++ b/DatamartExtractorSummary.md
@@ -1,31 +1,31 @@
 # DatamartsExtractorSummary 
-Creation date: 2024-03-19
+Creation date: 2024-05-08
  
-Started time: 11:59:05
+Started time: 15:27:10
  
-Creation time: 11:59:06
+Creation time: 17:58:51
  
-RegulonDB Version: 12.5
+RegulonDB Version: 13
 
 ## RegulonDB Datamarts Summary 
 
  ### geneDatamart: 
  4748 Total Objects Generated
  ### operonDatamart: 
- 2590 Total Objects Generated
+ 2613 Total Objects Generated
  ### regulonDatamart: 
  287 Total Objects Generated
  ### sigmulonDatamart: 
  7 Total Objects Generated
  ### dnaFeatures: 
- 14882 Total Objects Generated
+ 14917 Total Objects Generated
  ### regulatoryNetworkDatamart: 
  5035 Total Objects Generated
  ### listPage: 
- 7632 Total Objects Generated
+ 7655 Total Objects Generated
  ### gensorUnitDatamart: 
  238 Total Objects Generated
  ### mcoTree: 
- 5969 Total Objects Generated
+ 6288 Total Objects Generated
  ### downloadableFilesDatamart: 
  21 Total Objects Generated

--- a/__main__.py
+++ b/__main__.py
@@ -41,16 +41,16 @@ def load_arguments_parser():
     parser.add_argument(
         "-rdbv", "--rdbversion",
         help="RegulonDB Version",
-        metavar="12.5",
-        default="12.5",
+        metavar="13",
+        default="13",
         required=False
     )
 
     parser.add_argument(
         "-c", "--citation",
         help="RegulonDB citation for downloadable files",
-        metavar="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072\n# RegulonDB Release: 12.5",
-        default="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072\n# RegulonDB Release: 12.5",
+        metavar="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072\n# RegulonDB Release: 13.0",
+        default="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072\n# RegulonDB Release: 13.0",
         required=False
     )
 

--- a/__main__.py
+++ b/__main__.py
@@ -49,8 +49,8 @@ def load_arguments_parser():
     parser.add_argument(
         "-c", "--citation",
         help="RegulonDB citation for downloadable files",
-        metavar="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072",
-        default="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072",
+        metavar="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072\n# RegulonDB Release: 12.5",
+        default="# Heladia Salgado, Socorro Gama-Castro, et al., RegulonDB v12.0: a comprehensive resource of transcriptional regulation in E. coli K-12,\n# Nucleic Acids Research, 2023;, gkad1072, https://doi.org/10.1093/nar/gkad1072\n# RegulonDB Release: 12.5",
         required=False
     )
 

--- a/src/datamarts/domain/downloadableFiles_datamart/regulators_file.py
+++ b/src/datamarts/domain/downloadableFiles_datamart/regulators_file.py
@@ -35,6 +35,7 @@ class Regulators:
             self.regulator = regulator
             self.regulator_synonyms = regulator.synonyms
             self.genes = regulator
+            self.gene_bnumbers = regulator
             self.active_conf = active_conformations
             self.inactive_conf = regulator
             self.active_conf_syn = active_conformations
@@ -92,6 +93,24 @@ class Regulators:
                 self._genes += f"{gene.name};"
             if len(self._genes) > 0:
                 self._genes = self._genes[:-1]
+
+        @property
+        def gene_bnumbers(self):
+            return self._gene_bnumbers
+
+        @gene_bnumbers.setter
+        def gene_bnumbers(self, regulator):
+            self._gene_bnumbers = ""
+            if regulator.regulator_type == "transcriptionFactor":
+                for product_id in regulator.products_ids:
+                    product = multigenomic_api.products.find_by_id(product_id)
+                    gene = multigenomic_api.genes.find_by_id(product.genes_id)
+                    self._gene_bnumbers += f"{gene.bnumber};"
+            if regulator.regulator_type == "srna":
+                gene = multigenomic_api.genes.find_by_id(regulator.genes_id)
+                self._gene_bnumbers += f"{gene.bnumber};"
+            if len(self._gene_bnumbers) > 0:
+                self._gene_bnumbers = self._gene_bnumbers[:-1]
 
         @property
         def active_conf(self):
@@ -303,6 +322,7 @@ class Regulators:
                    f"\t{self.regulator_synonyms}" \
                    f"\t{self.regulator.regulator_type}" \
                    f"\t{self.genes}" \
+                   f"\t{self.gene_bnumbers}" \
                    f"\t{self.active_conf}" \
                    f"\t{self.inactive_conf}" \
                    f"\t{self.active_conf_syn}" \
@@ -403,7 +423,7 @@ def get_all_act_conf(regulator):
 
 def all_regulators_rows(rdb_version, citation):
     regulators = Regulators()
-    regulators_content = ["1)regulatorId\t2)regulatorName\t3)regulatorSynonyms\t4)regulatorType\t5)geneCodingForRegulator\t6)regulatorActiveConformations\t7)regulatorInactiveConformations\t8)regulatorActiveConformationsSynonyms\t9)regulatorInactiveConformationsSynonyms\t10)regulatorActiveConformationsEffector\t11)regulatorInactiveConformationsEffector\t12)regulatorActiveConformationsEffectorSynonyms\t13)regulatorInactiveConformationsEffectorSynonyms\t14)symmetry\t15)regulatorEvidences\t16)additiveEvidences\t17)confidenceLevel\t18)regulatorConformationPMID"]
+    regulators_content = ["1)regulatorId\t2)regulatorName\t3)regulatorSynonyms\t4)regulatorType\t5)geneCodingForRegulator\t6)geneBnumberCodingForRegulator\t7)regulatorActiveConformations\t8)regulatorInactiveConformations\t9)regulatorActiveConformationsSynonyms\t10)regulatorInactiveConformationsSynonyms\t11)regulatorActiveConformationsEffector\t12)regulatorInactiveConformationsEffector\t13)regulatorActiveConformationsEffectorSynonyms\t14)regulatorInactiveConformationsEffectorSynonyms\t15)symmetry\t16)regulatorEvidences\t17)additiveEvidences\t18)confidenceLevel\t19)regulatorConformationPMID"]
     for regulator in regulators.objects:
         regulators_content.append(regulator.to_row())
     creation_date = datetime.now()
@@ -421,7 +441,7 @@ def all_regulators_rows(rdb_version, citation):
         },
         "version": "1.0",
         "creationDate": f"{creation_date.strftime('%m-%d-%Y')}",
-        "columnsDetails": "# Columns:\n# (1) Regulator identifier assigned by RegulonDB\n# (2) Regulator Name\n# (3) Regulator Synonyms List\n# (4) Regulator Synonyms List\n# (5) Gene Coding for the Regulator\n# (6) Regulator Active Conformations\n# (7) Regulator Inactive Conformations\n# (8) Regulator Active Conformations Synonyms List\n# (9) Regulator Inactive Conformations Synonyms List\n# (10) Effector Name related to  Regulator Active Conformations\n# (11) Effector Name related to  Regulator Inactive Conformations\n# (12) Effector Synonyms List related to Regulator Active Conformations Regulator \n# (13) Effector Synonyms List related to Regulator Inactive Conformations Regulator\n# (14) Regulator Symmetry\n# (15) Evidence that supports the Regulator conformation [Evidence code | Evidence type: C = Confirmed, S = Strong, W = Weak | Evidence name ]\n# (16) addEvidence. Additive Evidence [CV(EvidenceCode1/EvidenceCodeN)|Confidence Level]\n# (17) confidenceLevel. Confidence level (Values: Confirmed, Strong, Weak)\n# (18) Regulator conformation reference identifier (PMID)",
+        "columnsDetails": "# Columns:\n# (1) Regulator identifier assigned by RegulonDB\n# (2) Regulator Name\n# (3) Regulator Synonyms List\n# (4) Regulator Synonyms List\n# (5) Gene Coding for the Regulator\n# (6) Gene Bnumber Coding for the Regulator\n# (7) Regulator Active Conformations\n# (8) Regulator Inactive Conformations\n# (9) Regulator Active Conformations Synonyms List\n# (10) Regulator Inactive Conformations Synonyms List\n# (11) Effector Name related to  Regulator Active Conformations\n# (12) Effector Name related to  Regulator Inactive Conformations\n# (13) Effector Synonyms List related to Regulator Active Conformations Regulator \n# (14) Effector Synonyms List related to Regulator Inactive Conformations Regulator\n# (15) Regulator Symmetry\n# (16) Evidence that supports the Regulator conformation [Evidence code | Evidence type: C = Confirmed, S = Strong, W = Weak | Evidence name ]\n# (17) addEvidence. Additive Evidence [CV(EvidenceCode1/EvidenceCodeN)|Confidence Level]\n# (18) confidenceLevel. Confidence level (Values: Confirmed, Strong, Weak)\n# (19) Regulator conformation reference identifier (PMID)",
         "content": " \n".join(regulators_content),
         "rdbVersion": rdb_version,
         "description": "Regulators and their conformations (Transcription factors, small RNAs, and ppGpp).",

--- a/src/datamarts/domain/downloadableFiles_datamart/transcriptionFactors_file.py
+++ b/src/datamarts/domain/downloadableFiles_datamart/transcriptionFactors_file.py
@@ -21,6 +21,7 @@ class TranscriptionFactor:
             self.tf = tf
             self.tf_synonyms = tf.synonyms
             self.genes = tf.products_ids
+            self.gene_bnumbers = tf.products_ids
             self.active_conf = active_conformations
             self.inactive_conf = tf.inactive_conformations
             self.active_conf_syn = active_conformations
@@ -59,6 +60,20 @@ class TranscriptionFactor:
                 self._genes += f"{gene.name};"
             if len(self._genes) > 0:
                 self._genes = self._genes[:-1]
+
+        @property
+        def gene_bnumbers(self):
+            return self._gene_bnumbers
+
+        @gene_bnumbers.setter
+        def gene_bnumbers(self, products_ids):
+            self._gene_bnumbers = ""
+            for product_id in products_ids:
+                product = multigenomic_api.products.find_by_id(product_id)
+                gene = multigenomic_api.genes.find_by_id(product.genes_id)
+                self._gene_bnumbers += f"{gene.bnumber};"
+            if len(self._gene_bnumbers) > 0:
+                self._gene_bnumbers = self._gene_bnumbers[:-1]
 
         @property
         def active_conf(self):
@@ -262,6 +277,7 @@ class TranscriptionFactor:
                    f"\t{self.tf.abbreviated_name}" \
                    f"\t{self.tf_synonyms}" \
                    f"\t{self.genes}" \
+                   f"\t{self.gene_bnumbers}" \
                    f"\t{self.active_conf}" \
                    f"\t{self.inactive_conf}" \
                    f"\t{self.active_conf_syn}" \
@@ -343,7 +359,7 @@ def get_all_act_conf(tf):
 
 def all_tfs_rows(rdb_version, citation):
     trans_factors = TranscriptionFactor()
-    tfs_content = ["1)tfId\t2)tfName\t3)tfSynonyms\t4)geneCodingForTF\t5)tfActiveConformations\t6)tfInactiveConformations\t7)tfActiveConformationsSynonyms\t8)tfInactiveConformationsSynonyms\t9)tfActiveConformationsEffector\t10)tfInactiveConformationsEffector\t11)tfActiveConformationsEffectorSynonyms\t12)tfInactiveConformationsEffectorSynonyms\t13)symmetry\t14)tfEvidences\t15)additiveEvidences\t16)confidenceLevel\t17)tfConformationPMID"]
+    tfs_content = ["1)tfId\t2)tfName\t3)tfSynonyms\t4)geneCodingForTF\t5)geneBnumberCodingForTF\t6)tfActiveConformations\t7)tfInactiveConformations\t8)tfActiveConformationsSynonyms\t9)tfInactiveConformationsSynonyms\t10)tfActiveConformationsEffector\t11)tfInactiveConformationsEffector\t12)tfActiveConformationsEffectorSynonyms\t13)tfInactiveConformationsEffectorSynonyms\t14)symmetry\t15)tfEvidences\t16)additiveEvidences\t17)confidenceLevel\t18)tfConformationPMID"]
     for tf in trans_factors.objects:
         tfs_content.append(tf.to_row())
     creation_date = datetime.now()
@@ -361,7 +377,7 @@ def all_tfs_rows(rdb_version, citation):
         },
         "version": "1.0",
         "creationDate": f"{creation_date.strftime('%m-%d-%Y')}",
-        "columnsDetails": "# Columns:\n# (1) Transcription Factor (TF) identifier assigned by RegulonDB\n# (2) TF Name\n# (3) TF Synonyms List\n# (4) Gene Coding for the TF\n# (5) TF Active Conformations\n# (6) TF Inactive Conformations\n# (7) TF Active Conformations  Synonyms List\n# (8) TF Inactive Conformations  Synonyms List\n# (9) Effector Name related to  TF Active Conformations\n# (10) Effector Name related to  TF Inactive Conformations\n# (11) Effector Synonyms List related to TF Active Conformations TF \n# (12) Effector Synonyms List related to TF Inactive Conformations TF\n# (13) TF Symmetry\n# (14) Evidence that supports the TF conformation [Evidence code | Evidence type: C = Confirmed, S = Strong, W = Weak | Evidence name ]\n# (15) addEvidence. Additive Evidence [CV(EvidenceCode1/EvidenceCodeN)|Confidence Level]\n# (16) confidenceLevel. Confidence level (Values: Confirmed, Strong, Weak)\n# (17) TF conformation reference identifier (PMID)",
+        "columnsDetails": "# Columns:\n# (1) Transcription Factor (TF) identifier assigned by RegulonDB\n# (2) TF Name\n# (3) TF Synonyms List\n# (4) Gene Coding for the TF\n# (5) Gene Bnumbers Coding for the TF\n# (6) TF Active Conformations\n# (7) TF Inactive Conformations\n# (8) TF Active Conformations  Synonyms List\n# (9) TF Inactive Conformations  Synonyms List\n# (10) Effector Name related to  TF Active Conformations\n# (11) Effector Name related to  TF Inactive Conformations\n# (12) Effector Synonyms List related to TF Active Conformations TF \n# (13) Effector Synonyms List related to TF Inactive Conformations TF\n# (14) TF Symmetry\n# (15) Evidence that supports the TF conformation [Evidence code | Evidence type: C = Confirmed, S = Strong, W = Weak | Evidence name ]\n# (16) addEvidence. Additive Evidence [CV(EvidenceCode1/EvidenceCodeN)|Confidence Level]\n# (17) confidenceLevel. Confidence level (Values: Confirmed, Strong, Weak)\n# (18) TF conformation reference identifier (PMID)",
         "content": " \n".join(tfs_content),
         "rdbVersion": rdb_version,
         "description": "Transcription factors and their conformations (subset of RegulatorSet).",

--- a/src/datamarts/domain/gene_datamart/regulation.py
+++ b/src/datamarts/domain/gene_datamart/regulation.py
@@ -8,6 +8,7 @@ class Regulation:
         self.regulators = self.operon
         self.promoters = self.operon
         self.regulatory_interactions = self.operon
+        self.sigma_factors = []
 
     @property
     def operon(self):
@@ -17,6 +18,15 @@ class Regulation:
     def operon(self, operon_gene):
         operon = Operon(operon_gene)
         self._operon = operon
+
+    @property
+    def sigma_factors(self):
+        return self._sigma_factors
+
+    @sigma_factors.setter
+    def sigma_factors(self, array):
+        operon = self.operon
+        self._sigma_factors = operon.get_sigma_factor_count()
 
     @property
     def regulators(self):
@@ -49,7 +59,8 @@ class Regulation:
             "statistics": {
                 "regulators": len(self.regulators),
                 "promoters": len(self.promoters),
-                "regulatoryInteractions": len(self.regulatory_interactions)
+                "regulatoryInteractions": len(self.regulatory_interactions),
+                "sigmaFactors": self.sigma_factors
             }
         }
         return regulation
@@ -62,6 +73,7 @@ class Operon:
         gene_id = operon_gene[1]
         self.promoters = []
         self.regulators = []
+        self.sigma_factors = []
         self.operon = operon
         self.transcription_units = multigenomic_api.transcription_units.find_by_operon_id(operon.id)
         self.arrangement = [self.transcription_units, gene_id]
@@ -113,6 +125,15 @@ class Operon:
                 '_id': promoter.id,
                 'name': promoter.name
             }
+            if promoter.binds_sigma_factor:
+                sigma_factor = multigenomic_api.sigma_factors.find_by_id(promoter.binds_sigma_factor.sigma_factors_id)
+                sigma_object = {
+                    "_id": sigma_factor.id,
+                    "name": sigma_factor.name
+                }
+                new_promoter["sigmaFactor"] = sigma_object
+                if sigma_object not in self.sigma_factors:
+                    self.sigma_factors.append(sigma_object)
             promoters.append(new_promoter.copy())
 
             if new_promoter not in self.promoters:
@@ -164,6 +185,9 @@ class Operon:
             "arrangement": self.arrangement
         }
         return operon
+
+    def get_sigma_factor_count(self):
+        return len(self.sigma_factors)
 
 
 def identify_dual(regulators, item):

--- a/src/datamarts/domain/regulon_datamart/regulatory_interactions.py
+++ b/src/datamarts/domain/regulon_datamart/regulatory_interactions.py
@@ -114,7 +114,7 @@ class RegulatoryInteractions(BiologicalBase):
             if strand == "forward":
                 self._regulated_genes = sorted(self._regulated_genes, key=lambda x: x["leftEndPosition"])
             else:
-                self._regulated_genes = sorted(self._regulated_genes, key=lambda x: x["rightEndPosition"])
+                self._regulated_genes = sorted(self._regulated_genes, key=lambda x: x["rightEndPosition"], reverse=True)
 
     @property
     def regulatory_binding_sites(self):


### PR DESCRIPTION
The following changes were applied: 

## New
- Added sigma factor related to regulated operons of genes.regulation extraction
- Added bnumber column on regulatorSet and TFSet downloadable files extraction
- Applied changes to be compatible with Ecocyc v28.0

## Fix
- The regulated genes in regulatory interactions now are displayed in order
- A release version were added to downloadable files
- Minor bugs fixed